### PR TITLE
Add grunt-cli to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ node_js:
 cache:
   directories:
     - node_modules
+install:
+  - "travis_retry npm install grunt-cli"
+  - "travis_retry npm install"
 script:
   - "grunt ci"


### PR DESCRIPTION
Without installing grunt-cli properly, you cannot utilise the package template
via grunt on Travis.