### PR TITLE
Add support for reporting coverage to coveralls.io

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,8 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-contrib-watch');
+	grunt.loadNpmTasks('grunt-coveralls');
+	grunt.loadNpmTasks('grunt-cover-ts');
 	grunt.loadNpmTasks('grunt-text-replace');
 	grunt.loadNpmTasks('grunt-ts');
 	grunt.loadNpmTasks('grunt-tslint');
@@ -86,6 +88,17 @@ module.exports = function (grunt) {
 			}
 		},
 
+		cover_ts: {
+			files: {
+				src: 'lcov.info',
+				dest: '<%= devDirectory %>lcov.info'
+			}
+		},
+
+		coveralls: {
+			src: '<%= devDirectory %>lcov.info'
+		},
+
 		dtsGenerator: {
 			options: {
 				baseDir: 'src',
@@ -107,19 +120,19 @@ module.exports = function (grunt) {
 			},
 			runner: {
 				options: {
-					reporters: [ 'runner', 'lcovhtml' ]
+					reporters: [ 'runner', 'lcovhtml', 'lcov' ]
 				}
 			},
 			local: {
 				options: {
 					config: '<%= devDirectory %>/tests/intern-local',
-					reporters: [ 'runner', 'lcovhtml' ]
+					reporters: [ 'runner', 'lcovhtml', 'lcov' ]
 				}
 			},
 			client: {
 				options: {
 					runType: 'client',
-					reporters: [ 'console', 'lcovhtml' ]
+					reporters: [ 'console', 'lcovhtml', 'lcov' ]
 				}
 			},
 			proxy: {
@@ -267,6 +280,6 @@ module.exports = function (grunt) {
 	grunt.registerTask('test', [ 'dev', 'intern:client' ]);
 	grunt.registerTask('test-local', [ 'dev', 'intern:local' ]);
 	grunt.registerTask('test-proxy', [ 'dev', 'intern:proxy' ]);
-	grunt.registerTask('ci', [ 'tslint', 'test' ]);
+	grunt.registerTask('ci', [ 'tslint', 'test', 'covert_ts', 'coveralls' ]);
 	grunt.registerTask('default', [ 'clean', 'dev' ]);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -280,6 +280,6 @@ module.exports = function (grunt) {
 	grunt.registerTask('test', [ 'dev', 'intern:client' ]);
 	grunt.registerTask('test-local', [ 'dev', 'intern:local' ]);
 	grunt.registerTask('test-proxy', [ 'dev', 'intern:proxy' ]);
-	grunt.registerTask('ci', [ 'tslint', 'test', 'covert_ts', 'coveralls' ]);
+	grunt.registerTask('ci', [ 'tslint', 'test', 'cover_ts', 'coveralls' ]);
 	grunt.registerTask('default', [ 'clean', 'dev' ]);
 };

--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
 		"url": "https://github.com/dojo/<< package-name >>.git"
 	},
 	"devDependencies": {
+		"coveralls": "2.11.2",
 		"dts-generator": "1.4.1",
 		"grunt": "0.4.5",
 		"grunt-contrib-clean": "0.6.0",
 		"grunt-contrib-copy": "0.8.0",
 		"grunt-contrib-watch": "0.6.1",
+		"grunt-coveralls": "1.0.0",
+		"grunt-cover-ts": "0.2.0",
 		"grunt-text-replace": "0.4.0",
 		"grunt-ts": "3.0.0",
 		"grunt-tslint": "2.0.0",


### PR DESCRIPTION
This adds support to the package for when `grunt ci` is run, it is then submitted to coveralls.io for code coverage tracking.