### PR TITLE
Bower should ignore 'tests' directory.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
 	},
 	"ignore": [
 		".*",
-		"test"
+		"tests"
 	],
 	"license": [ "BSD-3-Clause" ],
 	"moduleType": [ "amd" ]


### PR DESCRIPTION
Resolves #5.