### PR TITLE
Add code coverage/remapping; refactor grunt tasks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
+env:
+  global:
+    # Please get your own free key if you want to test yourself
+    - BROWSERSTACK_USERNAME: << USERNAME GOES HERE >>
+    - BROWSERSTACK_ACCESS_KEY: << ACCESS KEY GOES HERE >>
 cache:
   directories:
     - node_modules
+install:
+  - "travis_retry npm install grunt-cli"
+  - "travis_retry npm install"
 script:
-  - "grunt ci"
+  - "grunt"
+  - "grunt intern:node --combined"
+  - "grunt intern:remote --combined"
+  - "grunt remapIstanbul:ci"
+  - "grunt uploadCoverage"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,11 @@
 /* jshint node:true */
 
-function mixin(destination, source) {
-	for (var key in source) {
-		destination[key] = source[key];
+function mixin(destination) {
+	for (var i = 1; i < arguments.length; i++) {
+		var source = arguments[i];
+		for (var key in source) {
+			destination[key] = source[key];
+		}
 	}
 	return destination;
 }
@@ -16,10 +19,16 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-tslint');
 	grunt.loadNpmTasks('dts-generator');
 	grunt.loadNpmTasks('intern');
+	grunt.loadNpmTasks('remap-istanbul');
+
+	grunt.loadTasks('tasks');
 
 	var tsconfigContent = grunt.file.read('tsconfig.json');
 	var tsconfig = JSON.parse(tsconfigContent);
-	var compilerOptions = mixin({}, tsconfig.compilerOptions);
+	var tsOptions = mixin({}, tsconfig.compilerOptions, {
+		failOnTypeErrors: true,
+		fast: 'never'
+	});
 	tsconfig.filesGlob = tsconfig.filesGlob.map(function (glob) {
 		if (/^\.\//.test(glob)) {
 			// Remove the leading './' from the glob because grunt-ts
@@ -35,6 +44,7 @@ module.exports = function (grunt) {
 		name: packageJson.name,
 		version: packageJson.version,
 		tsconfig: tsconfig,
+		tsconfigContent: tsconfigContent,
 		all: [ '<%= tsconfig.filesGlob %>' ],
 		skipTests: [ '<%= all %>' , '!tests/**/*.ts' ],
 		staticTestFiles: 'tests/**/*.{html,css}',
@@ -60,8 +70,11 @@ module.exports = function (grunt) {
 					return false;
 				}
 			},
+			report: {
+				src: [ 'html-report/', 'coverage-final.json' ]
+			},
 			coverage: {
-				src: [ 'html-report/' ]
+				src: [ 'coverage-unmapped.json' ]
 			}
 		},
 
@@ -101,25 +114,19 @@ module.exports = function (grunt) {
 
 		intern: {
 			options: {
-				grep: grunt.option('grep') || '.*',
 				runType: 'runner',
-				config: '<%= devDirectory %>/tests/intern'
+				config: '<%= devDirectory %>/tests/intern',
+				reporters: [ 'Runner' ]
 			},
-			runner: {
-				options: {
-					reporters: [ 'Runner', 'LcovHtml' ]
-				}
-			},
+			remote: {},
 			local: {
 				options: {
-					config: '<%= devDirectory %>/tests/intern-local',
-					reporters: [ 'Runner', 'LcovHtml' ]
+					config: '<%= devDirectory %>/tests/intern-local'
 				}
 			},
-			client: {
+			node: {
 				options: {
-					runType: 'client',
-					reporters: [ 'Console', 'Lcovhtml' ]
+					runType: 'client'
 				}
 			},
 			proxy: {
@@ -162,20 +169,17 @@ module.exports = function (grunt) {
 		},
 
 		ts: {
-			options: mixin(
-				compilerOptions,
-				{
-					failOnTypeErrors: true,
-					fast: 'never'
-				}
-			),
+			options: tsOptions,
 			dev: {
 				outDir: '<%= devDirectory %>',
 				src: [ '<%= all %>' ]
 			},
 			dist: {
 				options: {
-					mapRoot: '../dist/_debug'
+					mapRoot: '../dist/_debug',
+					sourceMap: true,
+					inlineSourceMap: false,
+					inlineSources: true
 				},
 				outDir: 'dist',
 				src: [ '<%= skipTests %>' ]
@@ -211,43 +215,66 @@ module.exports = function (grunt) {
 					'dev'
 				]
 			}
-		}
-	});
+		},
 
-	grunt.registerMultiTask('rewriteSourceMaps', function () {
-		this.filesSrc.forEach(function (file) {
-			var map = JSON.parse(grunt.file.read(file));
-			var sourcesContent = map.sourcesContent = [];
-			var path = require('path');
-			map.sources = map.sources.map(function (source, index) {
-				sourcesContent[index] = grunt.file.read(path.resolve(path.dirname(file), source));
-				return source.replace(/^.*\/src\//, '');
-			});
-			grunt.file.write(file, JSON.stringify(map));
-		});
-		grunt.log.writeln('Rewrote ' + this.filesSrc.length + ' source maps');
-	});
-
-	grunt.registerMultiTask('rename', function () {
-		this.files.forEach(function (file) {
-			if (grunt.file.isFile(file.src[0])) {
-				grunt.file.mkdir(require('path').dirname(file.dest));
+		remapIstanbul: {
+			coverage: {
+				options: {
+					reports: {
+						'html': 'html-report',
+						'text': null
+					}
+				},
+				src: [ 'coverage-unmapped.json' ]
+			},
+			ci: {
+				options: {
+					reports: {
+						'lcovonly': 'coverage-final.lcov',
+						'text': null
+					}
+				},
+				src: [ 'coverage-unmapped.json' ]
 			}
-			require('fs').renameSync(file.src[0], file.dest);
-			grunt.verbose.writeln('Renamed ' + file.src[0] + ' to ' + file.dest);
-		});
-		grunt.log.writeln('Moved ' + this.files.length + ' files');
+		}
 	});
 
-	grunt.registerTask('updateTsconfig', function () {
-		var tsconfig = JSON.parse(tsconfigContent);
-		tsconfig.files = grunt.file.expand(tsconfig.filesGlob);
-
-		var output = JSON.stringify(tsconfig, null, '\t') + require('os').EOL;
-		if (output !== tsconfigContent) {
-			grunt.file.write('tsconfig.json', output);
-			tsconfigContent = output;
+	// Set some Intern-specific options if specified on the command line.
+	[ 'suites', 'functionalSuites', 'grep' ].forEach(function (option) {
+		var value = grunt.option(option);
+		if (value) {
+			if (option !== 'grep') {
+				value = value.split(',').map(function (string) { return string.trim(); });
+			}
+			grunt.config('intern.options.' + option, value);
 		}
+	});
+
+	function setCombined(combined) {
+		if (combined) {
+			grunt.config('intern.options.reporters', [
+				{ id: 'tests/support/Reporter', file: 'coverage-unmapped.json' }
+			]);
+		}
+	}
+	setCombined(grunt.option('combined'));
+
+	grunt.registerTask('test', function () {
+		var flags = Object.keys(this.flags);
+
+		if (!flags.length) {
+			flags.push('node');
+		}
+
+		grunt.option('force', true);
+		grunt.task.run('clean:coverage');
+		grunt.task.run('dev');
+		setCombined(true);
+		flags.forEach(function (flag) {
+			grunt.task.run('intern:' + flag);
+		});
+		grunt.task.run('remapIstanbul:coverage');
+		grunt.task.run('clean:coverage');
 	});
 
 	grunt.registerTask('dev', [
@@ -264,9 +291,6 @@ module.exports = function (grunt) {
 		'copy:staticFiles',
 		'dtsGenerator:dist'
 	]);
-	grunt.registerTask('test', [ 'dev', 'intern:client' ]);
-	grunt.registerTask('test-local', [ 'dev', 'intern:local' ]);
 	grunt.registerTask('test-proxy', [ 'dev', 'intern:proxy' ]);
-	grunt.registerTask('ci', [ 'tslint', 'test' ]);
 	grunt.registerTask('default', [ 'clean', 'dev' ]);
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
 		"url": "https://github.com/dojo/<< package-name >>.git"
 	},
 	"devDependencies": {
+		"codecov.io": "0.1.6",
+		"dojo-loader": "2.0.0-alpha.1",
 		"dts-generator": "1.5.0",
+		"glob": "3.2.7",
 		"grunt": "0.4.5",
 		"grunt-contrib-clean": "0.6.0",
 		"grunt-contrib-copy": "0.8.0",
@@ -20,8 +23,10 @@
 		"grunt-text-replace": "0.4.0",
 		"grunt-ts": "3.0.0",
 		"grunt-tslint": "2.5.0",
-		"tslint": "2.5.0",
 		"intern": "3.0.3",
+		"istanbul": "0.3.17",
+		"remap-istanbul": "git://github.com/sitepen/remap-istanbul.git#dd9f5cb3fe8d6261739ce0ccb49e7825239d43f9",
+		"tslint": "2.5.0",
 		"typescript": "1.6.2"
 	}
 }

--- a/tests/functional/all.ts
+++ b/tests/functional/all.ts
@@ -1,1 +1,1 @@
-export var removeThis = 1;
+export const removeThis = 1;

--- a/tests/intern-local.ts
+++ b/tests/intern-local.ts
@@ -1,11 +1,11 @@
 export * from './intern';
 
-export var tunnel = 'NullTunnel';
-export var tunnelOptions = {
+export const tunnel = 'NullTunnel';
+export const tunnelOptions = {
 	hostname: 'localhost',
 	port: '4444'
 };
 
-export var environments = [
+export const environments = [
 	{ browserName: 'chrome' }
 ];

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -1,7 +1,9 @@
-export var proxyPort = 9000;
+import intern = require('intern');
+
+export const proxyPort = 9000;
 
 // A fully qualified URL to the Intern proxy
-export var proxyUrl = 'http://localhost:9000/';
+export const proxyUrl = 'http://localhost:9000/';
 
 // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
 // specified browser environments in the `environments` array below as well. See
@@ -9,7 +11,7 @@ export var proxyUrl = 'http://localhost:9000/';
 // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
 // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
 // automatically
-export var capabilities = {
+export const capabilities = {
 	'browserstack.selenium_version': '2.46.0',
 	'browserstack.debug': false,
 	project: 'Dojo 2',
@@ -19,7 +21,7 @@ export var capabilities = {
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
 // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
 // capabilities options specified for an environment will be copied as-is
-export var environments = [
+export const environments = [
 	{ browserName: 'internet explorer', version: [ '9', '10', '11' ], platform: 'WINDOWS' },
 	{ browserName: 'firefox', os: 'WINDOWS' },
 	{ browserName: 'chrome', os: 'WINDOWS' },
@@ -27,26 +29,42 @@ export var environments = [
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-export var maxConcurrency = 2;
+export const maxConcurrency = 2;
 
 // Name of the tunnel class to use for WebDriver tests
-export var tunnel = 'BrowserStackTunnel';
+export const tunnel = 'BrowserStackTunnel';
+
+// Support running unit tests from a web server that isn't the intern proxy
+export const initialBaseUrl: string = (function () {
+	if (typeof location !== 'undefined' && location.pathname.indexOf('__intern/') > -1) {
+		return '/';
+	}
+	return null;
+})();
+
+// The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
+// loader
+export const loaders = {
+	'host-browser': 'node_modules/dojo-loader/loader.js',
+	'host-node': 'dojo-loader'
+};
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
 // can be used here
-export var loaderOptions = {
+export const loaderOptions = {
 	// Packages that should be registered with the loader in each testing environment
 	packages: [
 		{ name: 'src', location: '_build/src' },
-		{ name: 'tests', location: '_build/tests' }
+		{ name: 'tests', location: '_build/tests' },
+		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' }
 	]
 };
 
 // Non-functional test suite(s) to run in each browser
-export var suites = [ 'tests/unit/all' ];
+export const suites = [ 'tests/unit/all' ];
 
 // Functional test suite(s) to run in each browser once non-functional tests are completed
-export var functionalSuites = [ 'tests/functional/all' ];
+export const functionalSuites = [ 'tests/functional/all' ];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
-export var excludeInstrumentation = /(?:node_modules|bower_components|tests)[\/\\]/;
+export const excludeInstrumentation = /(?:node_modules|bower_components|tests)[\/\\]/;

--- a/tests/support/Reporter.ts
+++ b/tests/support/Reporter.ts
@@ -1,0 +1,107 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as intern from 'intern';
+import Collector = require('istanbul/lib/collector');
+import glob = require('glob');
+import JsonReporter = require('istanbul/lib/report/json');
+import Instrumenter = require('istanbul/lib/instrumenter');
+import 'istanbul/index';
+
+import Runner = require('intern/lib/reporters/Runner');
+
+class Reporter extends Runner {
+	private _filename: string;
+	private _collector: Collector;
+	private _reporter: JsonReporter;
+	private reporter: any;
+
+	constructor(config: any = {}) {
+		super(config);
+
+		this._filename = config.file || 'coverage-final.json';
+		this._collector = new Collector();
+		this.reporter = {
+			writeReport: function () {}
+		};
+		this._reporter = new JsonReporter({
+			file: this._filename,
+			watermarks: config.watermarks
+		});
+	}
+
+	coverage(sessionId: string, coverage: any) {
+		if (intern.mode === 'client' || sessionId) {
+			const session = this.sessions[sessionId || ''];
+			session.coverage = true;
+			this._collector.add(coverage);
+		}
+	}
+
+	runEnd() {
+		let numEnvironments = 0;
+		let numTests = 0;
+		let numFailedTests = 0;
+		let numSkippedTests = 0;
+
+		for (const sessionId in this.sessions) {
+			const session = this.sessions[sessionId];
+			++numEnvironments;
+			numTests += session.suite.numTests;
+			numFailedTests += session.suite.numFailedTests;
+			numSkippedTests += session.suite.numSkippedTests;
+		}
+
+		this.charm.write('\n');
+
+		let message = `TOTAL: tested ${numEnvironments} platforms, ${numFailedTests}/${numTests} failed`;
+
+		if (numSkippedTests) {
+			message += ` (${numSkippedTests} skipped)`;
+		}
+		if (this.hasErrors && !numFailedTests) {
+			message += '; fatal error occurred';
+		}
+
+		this.charm
+			.foreground(numFailedTests > 0 || this.hasErrors ? 'red' : 'green')
+			.write(message)
+			.display('reset')
+			.write('\n');
+
+		this._writeCoverage();
+	}
+
+	_writeCoverage(): void {
+		let coverage: any;
+		if (fs.existsSync(this._filename)) {
+			coverage = JSON.parse(fs.readFileSync(this._filename, { encoding: 'utf8' }));
+		}
+		else {
+			coverage = {};
+			const coveredFiles = this._collector.files();
+			const instrumenter = new Instrumenter({
+				noCompact: true,
+				noAutoWrap: true
+			});
+			glob.sync('_build/**/*.js').filter(function (filepath) {
+				return !(<any> intern.executor).config.excludeInstrumentation.test(filepath) && coveredFiles.indexOf(path.resolve(filepath)) === -1;
+			}).forEach(function (filepath) {
+				try {
+					const wholename = path.resolve(filepath);
+					instrumenter.instrumentSync(fs.readFileSync(wholename, 'utf8'), wholename);
+					coverage[wholename] = instrumenter.lastFileCoverage();
+					for (let i in coverage[wholename].s) {
+						coverage[wholename].s[i] = 0;
+					}
+				}
+				catch (error) {
+					console.error(filepath + ': ' + error);
+				}
+			});
+		}
+		this._collector.add(coverage);
+		this._reporter.writeReport(this._collector, true);
+	}
+}
+
+export = Reporter;

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -1,0 +1,19 @@
+/**
+ * Thenable represents any object with a callable `then` property.
+ */
+export interface Thenable<T> {
+	then<U>(onFulfilled?: (value?: T) => U | Thenable<U>, onRejected?: (error?: any) => U | Thenable<U>): Thenable<U>;
+}
+
+export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean> {
+	return promise.then<any>(function () {
+		throw new Error('unexpected code path');
+	}, function () {
+		return true; // expect rejection
+	});
+}
+
+export function throwImmediatly() {
+	throw new Error('unexpected code path');
+}
+

--- a/tests/typings/chai/chai.d.ts
+++ b/tests/typings/chai/chai.d.ts
@@ -1,67 +1,67 @@
-// Type definitions for chai 1.7.2
+// Type definitions for chai 2.0.0
 // Project: http://chaijs.com/
-// Definitions by: Jed Hunsaker <https://github.com/jedhunsaker/>, Bart van der Schoor <https://github.com/Bartvds>
+// Definitions by: Jed Mao <https://github.com/jedmao/>,
+//                 Bart van der Schoor <https://github.com/Bartvds>,
+//                 Andrew Brown <https://github.com/AGBrown>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module chai {
-    export class AssertionError {
-        constructor(message: string, _props?: any, ssf?: Function);
-        name: string;
-        message: string;
-        showDiff: boolean;
-        stack: string;
+declare module Chai {
+
+    interface ChaiStatic {
+        expect: ExpectStatic;
+        should(): Should;
+        /**
+         * Provides a way to extend the internals of Chai
+         */
+        use(fn: (chai: any, utils: any) => void): any;
+        assert: AssertStatic;
+        config: Config;
     }
 
-    export function expect(target: any, message?: string): Expect;
-
-    export var assert: Assert;
-    export var config: Config;
-
-    export interface Config {
-        includeStack: boolean;
+    export interface ExpectStatic extends AssertionStatic {
     }
 
-    // Provides a way to extend the internals of Chai
-    function use(fn: (chai: any, utils: any) => void): any;
-
-    interface ExpectStatic {
-        (target: any): Expect;
+    export interface AssertStatic extends Assert {
     }
 
-    interface Assertions {
-        attr(name: string, value?: string): any;
-        css(name: string, value?: string): any;
-        data(name: string, value?: string): any;
-        class(className: string): any;
-        id(id: string): any;
-        html(html: string): any;
-        text(text: string): any;
-        value(value: string): any;
-        visible: any;
-        hidden: any;
-        selected: any;
-        checked: any;
-        disabled: any;
-        empty: any;
-        exist: any;
+    export interface AssertionStatic {
+        (target: any, message?: string): Assertion;
     }
 
-    interface Expect extends LanguageChains, NumericComparison, TypeComparison, Assertions {
-        not: Expect;
+    interface ShouldAssertion {
+        equal(value1: any, value2: any, message?: string): void;
+        Throw: ShouldThrow;
+        throw: ShouldThrow;
+        exist(value: any, message?: string): void;
+    }
+
+    interface Should extends ShouldAssertion {
+        not: ShouldAssertion;
+        fail(actual: any, expected: any, message?: string, operator?: string): void;
+    }
+
+    interface ShouldThrow {
+        (actual: Function): void;
+        (actual: Function, expected: string|RegExp, message?: string): void;
+        (actual: Function, constructor: Error|Function, expected?: string|RegExp, message?: string): void;
+    }
+
+    interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
+        not: Assertion;
         deep: Deep;
         a: TypeComparison;
         an: TypeComparison;
         include: Include;
         contain: Include;
-        ok: Expect;
-        true: Expect;
-        false: Expect;
-        null: Expect;
-        undefined: Expect;
-        exist: Expect;
-        empty: Expect;
-        arguments: Expect;
-        Arguments: Expect;
+        ok: Assertion;
+        true: Assertion;
+        false: Assertion;
+        null: Assertion;
+        undefined: Assertion;
+        exist: Assertion;
+        empty: Assertion;
+        arguments: Assertion;
+        Arguments: Assertion;
         equal: Equal;
         equals: Equal;
         eq: Equal;
@@ -72,33 +72,34 @@ declare module chai {
         haveOwnProperty: OwnProperty;
         length: Length;
         lengthOf: Length;
-        match(RegularExpression: RegExp, message?: string): Expect;
-        string(string: string, message?: string): Expect;
+        match(regexp: RegExp|string, message?: string): Assertion;
+        string(string: string, message?: string): Assertion;
         keys: Keys;
-        key(string: string): Expect;
+        key(string: string): Assertion;
         throw: Throw;
         throws: Throw;
         Throw: Throw;
-        respondTo(method: string, message?: string): Expect;
-        itself: Expect;
-        satisfy(matcher: Function, message?: string): Expect;
-        closeTo(expected: number, delta: number, message?: string): Expect;
+        respondTo(method: string, message?: string): Assertion;
+        itself: Assertion;
+        satisfy(matcher: Function, message?: string): Assertion;
+        closeTo(expected: number, delta: number, message?: string): Assertion;
         members: Members;
     }
 
     interface LanguageChains {
-        to: Expect;
-        be: Expect;
-        been: Expect;
-        is: Expect;
-        that: Expect;
-        and: Expect;
-        have: Expect;
-        has: Expect;
-        with: Expect;
-        at: Expect;
-        of: Expect;
-        same: Expect;
+        to: Assertion;
+        be: Assertion;
+        been: Assertion;
+        is: Assertion;
+        that: Assertion;
+        which: Assertion;
+        and: Assertion;
+        has: Assertion;
+        have: Assertion;
+        with: Assertion;
+        at: Assertion;
+        of: Assertion;
+        same: Assertion;
     }
 
     interface NumericComparison {
@@ -112,173 +113,196 @@ declare module chai {
         lessThan: NumberComparer;
         most: NumberComparer;
         lte: NumberComparer;
-        within(start: number, finish: number, message?: string): Expect;
+        within(start: number, finish: number, message?: string): Assertion;
     }
 
     interface NumberComparer {
-        (value: number, message?: string): Expect;
+        (value: number, message?: string): Assertion;
     }
 
     interface TypeComparison {
-        (type: string, message?: string): Expect;
+        (type: string, message?: string): Assertion;
         instanceof: InstanceOf;
         instanceOf: InstanceOf;
     }
 
     interface InstanceOf {
-        (constructor: Object, message?: string): Expect;
+        (constructor: Object, message?: string): Assertion;
     }
 
     interface Deep {
         equal: Equal;
+        include: Include;
         property: Property;
     }
 
     interface Equal {
-        (value: any, message?: string): Expect;
+        (value: any, message?: string): Assertion;
     }
 
     interface Property {
-        (name: string, value?: any, message?: string): Expect;
+        (name: string, value?: any, message?: string): Assertion;
     }
 
     interface OwnProperty {
-        (name: string, message?: string): Expect;
+        (name: string, message?: string): Assertion;
     }
 
     interface Length extends LanguageChains, NumericComparison {
-        (length: number, message?: string): Expect;
+        (length: number, message?: string): Assertion;
     }
 
     interface Include {
-        (value: Object, message?: string): Expect;
-        (value: string, message?: string): Expect;
-        (value: number, message?: string): Expect;
+        (value: Object, message?: string): Assertion;
+        (value: string, message?: string): Assertion;
+        (value: number, message?: string): Assertion;
         keys: Keys;
         members: Members;
     }
 
     interface Keys {
-        (...keys: string[]): Expect;
-        (keys: any[]): Expect;
-    }
-
-    interface Members {
-        (set: any[], message?: string): Expect;
+        (...keys: string[]): Assertion;
+        (keys: any[]): Assertion;
     }
 
     interface Throw {
-        (): Expect;
-        (expected: string, message?: string): Expect;
-        (expected: RegExp, message?: string): Expect;
-        (constructor: Error, expected?: string, message?: string): Expect;
-        (constructor: Error, expected?: RegExp, message?: string): Expect;
-        (constructor: Function, expected?: string, message?: string): Expect;
-        (constructor: Function, expected?: RegExp, message?: string): Expect;
+        (): Assertion;
+        (expected: string, message?: string): Assertion;
+        (expected: RegExp, message?: string): Assertion;
+        (constructor: Error, expected?: string, message?: string): Assertion;
+        (constructor: Error, expected?: RegExp, message?: string): Assertion;
+        (constructor: Function, expected?: string, message?: string): Assertion;
+        (constructor: Function, expected?: RegExp, message?: string): Assertion;
+    }
+
+    interface Members {
+        (set: any[], message?: string): Assertion;
     }
 
     export interface Assert {
-        (express: any, msg?: string):void;
+        /**
+         * @param expression Expression to test for truthiness.
+         * @param message Message to display on error.
+         */
+        (expression: any, message?: string): void;
 
-        fail(actual?: any, expected?: any, msg?: string, operator?: string):void;
+        fail(actual?: any, expected?: any, msg?: string, operator?: string): void;
 
-        ok(val: any, msg?: string):void;
-        notOk(val: any, msg?: string):void;
+        ok(val: any, msg?: string): void;
+        notOk(val: any, msg?: string): void;
 
-        equal(act: any, exp: any, msg?: string):void;
-        notEqual(act: any, exp: any, msg?: string):void;
+        equal(act: any, exp: any, msg?: string): void;
+        notEqual(act: any, exp: any, msg?: string): void;
 
-        strictEqual(act: any, exp: any, msg?: string):void;
-        notStrictEqual(act: any, exp: any, msg?: string):void;
+        strictEqual(act: any, exp: any, msg?: string): void;
+        notStrictEqual(act: any, exp: any, msg?: string): void;
 
-        deepEqual(act: any, exp: any, msg?: string):void;
-        notDeepEqual(act: any, exp: any, msg?: string):void;
+        deepEqual(act: any, exp: any, msg?: string): void;
+        notDeepEqual(act: any, exp: any, msg?: string): void;
 
-        isTrue(val: any, msg?: string):void;
-        isFalse(val: any, msg?: string):void;
+        isTrue(val: any, msg?: string): void;
+        isFalse(val: any, msg?: string): void;
 
-        isNull(val: any, msg?: string):void;
-        isNotNull(val: any, msg?: string):void;
+        isNull(val: any, msg?: string): void;
+        isNotNull(val: any, msg?: string): void;
 
-        isUndefined(val: any, msg?: string):void;
-        isDefined(val: any, msg?: string):void;
+        isUndefined(val: any, msg?: string): void;
+        isDefined(val: any, msg?: string): void;
 
-        isFunction(val: any, msg?: string):void;
-        isNotFunction(val: any, msg?: string):void;
+        isFunction(val: any, msg?: string): void;
+        isNotFunction(val: any, msg?: string): void;
 
-        isObject(val: any, msg?: string):void;
-        isNotObject(val: any, msg?: string):void;
+        isObject(val: any, msg?: string): void;
+        isNotObject(val: any, msg?: string): void;
 
-        isArray(val: any, msg?: string):void;
-        isNotArray(val: any, msg?: string):void;
+        isArray(val: any, msg?: string): void;
+        isNotArray(val: any, msg?: string): void;
 
-        isString(val: any, msg?: string):void;
-        isNotString(val: any, msg?: string):void;
+        isString(val: any, msg?: string): void;
+        isNotString(val: any, msg?: string): void;
 
-        isNumber(val: any, msg?: string):void;
-        isNotNumber(val: any, msg?: string):void;
+        isNumber(val: any, msg?: string): void;
+        isNotNumber(val: any, msg?: string): void;
 
-        isBoolean(val: any, msg?: string):void;
-        isNotBoolean(val: any, msg?: string):void;
+        isBoolean(val: any, msg?: string): void;
+        isNotBoolean(val: any, msg?: string): void;
 
-        typeOf(val: any, type: string, msg?: string):void;
-        notTypeOf(val: any, type: string, msg?: string):void;
+        typeOf(val: any, type: string, msg?: string): void;
+        notTypeOf(val: any, type: string, msg?: string): void;
 
-        instanceOf(val: any, type: Function, msg?: string):void;
-        notInstanceOf(val: any, type: Function, msg?: string):void;
+        instanceOf(val: any, type: Function, msg?: string): void;
+        notInstanceOf(val: any, type: Function, msg?: string): void;
 
-        include(exp: string, inc: any, msg?: string):void;
-        include(exp: any[], inc: any, msg?: string):void;
+        include(exp: string, inc: any, msg?: string): void;
+        include(exp: any[], inc: any, msg?: string): void;
 
-        notInclude(exp: string, inc: any, msg?: string):void;
-        notInclude(exp: any[], inc: any, msg?: string):void;
+        notInclude(exp: string, inc: any, msg?: string): void;
+        notInclude(exp: any[], inc: any, msg?: string): void;
 
-        match(exp: any, re: RegExp, msg?: string):void;
-        notMatch(exp: any, re: RegExp, msg?: string):void;
+        match(exp: any, re: RegExp, msg?: string): void;
+        notMatch(exp: any, re: RegExp, msg?: string): void;
 
-        property(obj: Object, prop: string, msg?: string):void;
-        notProperty(obj: Object, prop: string, msg?: string):void;
-        deepProperty(obj: Object, prop: string, msg?: string):void;
-        notDeepProperty(obj: Object, prop: string, msg?: string):void;
+        property(obj: Object, prop: string, msg?: string): void;
+        notProperty(obj: Object, prop: string, msg?: string): void;
+        deepProperty(obj: Object, prop: string, msg?: string): void;
+        notDeepProperty(obj: Object, prop: string, msg?: string): void;
 
-        propertyVal(obj: Object, prop: string, val: any, msg?: string):void;
-        propertyNotVal(obj: Object, prop: string, val: any, msg?: string):void;
+        propertyVal(obj: Object, prop: string, val: any, msg?: string): void;
+        propertyNotVal(obj: Object, prop: string, val: any, msg?: string): void;
 
-        deepPropertyVal(obj: Object, prop: string, val: any, msg?: string):void;
-        deepPropertyNotVal(obj: Object, prop: string, val: any, msg?: string):void;
+        deepPropertyVal(obj: Object, prop: string, val: any, msg?: string): void;
+        deepPropertyNotVal(obj: Object, prop: string, val: any, msg?: string): void;
 
-        lengthOf(exp: any, len: number, msg?: string):void;
+        lengthOf(exp: any, len: number, msg?: string): void;
         //alias frenzy
-        throw(fn: Function, msg?: string):void;
-        throw(fn: Function, regExp: RegExp):void;
-        throw(fn: Function, errType: Function, msg?: string):void;
-        throw(fn: Function, errType: Function, regExp: RegExp):void;
+        throw(fn: Function, msg?: string): void;
+        throw(fn: Function, regExp: RegExp): void;
+        throw(fn: Function, errType: Function, msg?: string): void;
+        throw(fn: Function, errType: Function, regExp: RegExp): void;
 
-        throws(fn: Function, msg?: string):void;
-        throws(fn: Function, regExp: RegExp):void;
-        throws(fn: Function, errType: Function, msg?: string):void;
-        throws(fn: Function, errType: Function, regExp: RegExp):void;
+        throws(fn: Function, msg?: string): void;
+        throws(fn: Function, regExp: RegExp): void;
+        throws(fn: Function, errType: Function, msg?: string): void;
+        throws(fn: Function, errType: Function, regExp: RegExp): void;
 
-        Throw(fn: Function, msg?: string):void;
-        Throw(fn: Function, regExp: RegExp):void;
-        Throw(fn: Function, errType: Function, msg?: string):void;
-        Throw(fn: Function, errType: Function, regExp: RegExp):void;
+        Throw(fn: Function, msg?: string): void;
+        Throw(fn: Function, regExp: RegExp): void;
+        Throw(fn: Function, errType: Function, msg?: string): void;
+        Throw(fn: Function, errType: Function, regExp: RegExp): void;
 
-        doesNotThrow(fn: Function, msg?: string):void;
-        doesNotThrow(fn: Function, regExp: RegExp):void;
-        doesNotThrow(fn: Function, errType: Function, msg?: string):void;
-        doesNotThrow(fn: Function, errType: Function, regExp: RegExp):void;
+        doesNotThrow(fn: Function, msg?: string): void;
+        doesNotThrow(fn: Function, regExp: RegExp): void;
+        doesNotThrow(fn: Function, errType: Function, msg?: string): void;
+        doesNotThrow(fn: Function, errType: Function, regExp: RegExp): void;
 
-        operator(val: any, operator: string, val2: any, msg?: string):void;
-        closeTo(act: number, exp: number, delta: number, msg?: string):void;
+        operator(val: any, operator: string, val2: any, msg?: string): void;
+        closeTo(act: number, exp: number, delta: number, msg?: string): void;
 
-        sameMembers(set1: any[], set2: any[], msg?: string):void;
-        includeMembers(set1: any[], set2: any[], msg?: string):void;
+        sameMembers(set1: any[], set2: any[], msg?: string): void;
+        includeMembers(set1: any[], set2: any[], msg?: string): void;
 
-        ifError(val: any, msg?: string):void;
+        ifError(val: any, msg?: string): void;
+    }
+
+    export interface Config {
+        includeStack: boolean;
+    }
+
+    export class AssertionError {
+        constructor(message: string, _props?: any, ssf?: Function);
+        name: string;
+        message: string;
+        showDiff: boolean;
+        stack: string;
     }
 }
 
+declare var chai: Chai.ChaiStatic;
+
 declare module "chai" {
     export = chai;
+}
+
+interface Object {
+    should: Chai.Assertion;
 }

--- a/tests/typings/leadfoot/leadfoot.d.ts
+++ b/tests/typings/leadfoot/leadfoot.d.ts
@@ -1,5 +1,4 @@
 /// <reference path="../dojo2/dojo.d.ts" />
-/// <reference path="../node/node.d.ts" />
 
 declare module leadfoot {
 //	import request = require('dojo/request');
@@ -636,7 +635,7 @@ declare module 'leadfoot/Command' {
 		 *
 		 * @param numCommandsToPop The number of element contexts to pop. Defaults to 1.
 		 */
-		end<U>(numCommandsToPop: number): Promise<U>;
+		end(numCommandsToPop?: number): Command<void>;
 
 		/**
 		 * Adds a callback to be invoked once the previously chained operation has completed.
@@ -657,7 +656,7 @@ declare module 'leadfoot/Command' {
 		 */
 		then<U>(
 			callback: (value: T, setContext?: Command.ContextSetter) => Promise.Thenable<U> | U,
-			errback: (error: Error, setContext?: Command.ContextSetter) => Promise.Thenable<U> | U
+			errback?: (error: Error, setContext?: Command.ContextSetter) => Promise.Thenable<U> | U
 		): Command<U>;
 
 		/**

--- a/tests/typings/tsd.d.ts
+++ b/tests/typings/tsd.d.ts
@@ -1,2 +1,86 @@
 /// <reference path="intern/intern.d.ts" />
-/// <reference path="node/node.d.ts" />
+
+declare module 'intern/dojo/Promise' {
+	import Promise = require('dojo/Promise');
+	export = Promise;
+}
+
+declare module 'intern/lib/util' {
+	export function getErrorMessage(error: any): string;
+}
+
+declare module 'intern/lib/reporters/Runner' {
+	import charm = require('charm');
+	class Runner {
+		protected charm: charm.Charm;
+		protected hasErrors: boolean;
+		protected sessions: any;
+
+		constructor(config?: any);
+	}
+	export = Runner;
+}
+
+declare module 'istanbul/lib/collector' {
+	class Collector {
+		add(coverage: any): void;
+		files(): string[];
+	}
+
+	export = Collector;
+}
+
+declare module 'istanbul/lib/report/json' {
+	import Collector = require('istanbul/lib/collector');
+	class JsonReporter {
+		constructor(options: any);
+
+		writeReport(collector: Collector, sync: boolean): void;
+	}
+	export = JsonReporter;
+}
+
+declare module 'istanbul/lib/instrumenter' {
+	class Instrumenter {
+		constructor(options?: any);
+
+		instrumentSync(code: string, path: string): string;
+		lastFileCoverage(): any;
+	}
+	export = Instrumenter;
+}
+
+declare module 'istanbul/index' {
+	let result: any;
+	export = result;
+}
+
+declare module 'glob' {
+	const glob: {
+		(pattern: string, callback: (err: Error, matches: string[]) => void): void;
+		(pattern: string, options: any, callback: (err: Error, matches: string[]) => void): void;
+
+		sync(pattern: string, options?: any): string[];
+	};
+	export = glob;
+}
+
+declare module 'charm' {
+	import { Stream } from 'stream';
+
+	const charm: {
+		(): charm.Charm;
+	};
+	module charm {
+		export interface Charm extends Stream {
+			reset(): Charm;
+			destroy(): void;
+			end(): void;
+			write(buf: string): Charm;
+			display(attr: string): Charm;
+			foreground(color: string|number): Charm;
+			background(color: string|number): Charm;
+		}
+	}
+	export = charm;
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,1 +1,1 @@
-export var removeThis = 1;
+export const removeThis = 1;


### PR DESCRIPTION
Resolving #12, this includes:
* Istanbul coverage/remapping.
* Updated typings.
* Refactored grunt tasks.
* Cleaned-up intern config.

I tested these changes by cloning the template into a separate repository, adding modules and tests, and running the Grunt tasks and coverage reports.

There is one thing we may want to handle differently: `util.ts` in core imports and exports the `Thenable` interface from `Promise.ts`. Instead of including core just for this interface, it is inlined directly in `util.ts`.