### PR TITLE
Add grunt `release` task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-contrib-watch');
+	grunt.loadNpmTasks('grunt-release');
 	grunt.loadNpmTasks('grunt-text-replace');
 	grunt.loadNpmTasks('grunt-ts');
 	grunt.loadNpmTasks('grunt-tslint');
@@ -126,6 +127,21 @@ module.exports = function (grunt) {
 				options: {
 					proxyOnly: true
 				}
+			}
+		},
+
+		release: {
+			options: {
+				// Update the bower.json version as well
+				additionalFiles: [ 'bower.json' ],
+				// Run tasks after the version has been updated in package.json and bower.json
+				afterBump: [ 'clean', 'dist' ],
+				// Publish the "dist/" directory to npm
+				folder: 'dist/',
+				commitMessage: 'Updating source version to <%= version %>',
+				tagMessage: 'Release <%= version %>',
+				// Update the `version` property on the `packageJson` object.
+				updateVars: [ packageJson ]
 			}
 		},
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"grunt-contrib-clean": "0.6.0",
 		"grunt-contrib-copy": "0.8.0",
 		"grunt-contrib-watch": "0.6.1",
+		"grunt-release": "0.13.0",
 		"grunt-text-replace": "0.4.0",
 		"grunt-ts": "3.0.0",
 		"grunt-tslint": "2.5.0",


### PR DESCRIPTION
Partially resolves https://github.com/dojo/core/issues/36, but changes are added to this repo since they could be replicated across all dojo packages. "Partially" since no mechanism for publishing to Bower is included.

This adds the [grunt-release](https://github.com/geddski/grunt-release) dependency with a Grunt `release` task that will:
1. Update the version (according to semver) in bower.json, package.json, and the local config object.
2. Run the `clean` and `dist` tasks.
3. Commit and push the package.json and bower.json changes, along with the Git tags.
4. Publish to npm.

I have tested this in a separate, personal repository (without the `npm` flag) to confirm that this functions properly.