### PR TITLE
Tslint tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
 		"grunt-release": "0.13.0",
 		"grunt-text-replace": "0.4.0",
 		"grunt-ts": "5.3.2",
-		"grunt-tslint": "3.0.3",
+		"grunt-tslint": "3.1.0",
 		"intern": "3.0.6",
 		"istanbul": "0.4.2",
 		"remap-istanbul": "0.5.1",
-		"tslint": "3.5.0",
+		"tslint": "3.10.1",
 		"typescript": "1.8.2"
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,11 +8,11 @@
 		"eofline": true,
 		"forin": false,
 		"indent": [ true, "tabs" ],
-		"interface-name": false,
+		"interface-name": [ true, "never-prefix" ],
 		"jsdoc-format": true,
 		"label-position": true,
 		"label-undefined": true,
-		"max-line-length": false,
+		"max-line-length": 120,
 		"member-access": false,
 		"member-ordering": false,
 		"no-any": false,
@@ -27,6 +27,7 @@
 		"no-duplicate-variable": true,
 		"no-empty": false,
 		"no-eval": true,
+		"no-inferrable-types": [ true, "ignore-params" ],
 		"no-shadowed-variable": false,
 		"no-string-literal": false,
 		"no-switch-case-fall-through": false,
@@ -41,7 +42,7 @@
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
 		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": true,
+		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -54,9 +55,15 @@
 			"parameter": "nospace",
 			"property-declaration": "nospace",
 			"variable-declaration": "nospace"
+		}, {
+			"call-signature": "onespace",
+			"index-signature": "onespace",
+			"parameter": "onespace",
+			"property-declaration": "onespace",
+			"variable-declaration": "onespace"
 		} ],
 		"use-strict": false,
-		"variable-name": false,
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ],
 		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
 	}
 }


### PR DESCRIPTION
Bump dependencies.

Set interface-name to 'never-prefix', though I'm not sure whether this is different from setting it to 'false' at least it's more explicit.

Enforce a maximum line length.

Set semicolons to 'always'. Like with interface-name this is more explicit.

Update typedef-whitespace to require one space *after* colons. Again for explicitness sake.

Add variable-name rule, enabling just the options that match the style guide.

---

See the [Core Rules](https://github.com/palantir/tslint#core-rules).