### PR TITLE
Make intern.ts work with strictNullChecks

### DIFF
--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -32,7 +32,7 @@ export const maxConcurrency = 2;
 export const tunnel = 'BrowserStackTunnel';
 
 // Support running unit tests from a web server that isn't the intern proxy
-export const initialBaseUrl: string = (function () {
+export const initialBaseUrl: string | null = (function () {
 	if (typeof location !== 'undefined' && location.pathname.indexOf('__intern/') > -1) {
 		return '/';
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
 	"version": "2.0.0",
 	"compilerOptions": {
+		"baseUrl": "node_modules",
 		"declaration": false,
 		"module": "umd",
+		"moduleResolution": "classic",
 		"noImplicitAny": true,
 		"noImplicitThis": true,
-		"strictNullChecks": true,
 		"outDir": "_build/",
-		"baseUrl": "node_modules",
 		"paths": {},
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es5",
-		"moduleResolution": "classic"
+		"strictNullChecks": true,
+		"target": "es5"
 	},
 	"include": [
 		"./typings/index.d.ts",


### PR DESCRIPTION
This modifies the default `intern.ts` to work when `strictNullChecks` is enabled.

It also alphabetises the order of the compiler options to make it easier to locate properties.