### PR TITLE
Update .gitignore so JS files are not ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-*.js
-*.js.map
-!/*.js
-!/tasks/*.js
 /_build
 /bower_components
 /dist


### PR DESCRIPTION
This PR modifies `.gitignore` so JS files aren't blindly ignored throughout the repository. Suggested [here](https://github.com/dojo/widgets/pull/35/files/d4ee1411c9acf2b004a8145cbb271740de4b4b01#r79136003).
