### PR TITLE
Switch tsconfig to use node module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,12 +7,10 @@
 		"noImplicitThis": true,
 		"strictNullChecks": true,
 		"outDir": "_build/",
-		"baseUrl": "node_modules",
-		"paths": {},
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
-		"moduleResolution": "classic"
+		"moduleResolution": "node"
 	},
 	"include": [
 		"./typings/index.d.ts",


### PR DESCRIPTION
**Type:** feature

**Description:**
Switch to using `node` for `moduleResolution`, which means we also no longer need `baseUrl` or `paths`
