### PR TITLE
Specify 'engines' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "dojo-<< package-name >>",
   "version": "2.0.0-pre",
   "description": "<< DESCRIPTION GOES HERE >>",
+  "engines": {
+    "node": "^6.5.0",
+    "npm": "^3.10.0"
+  },
   "private": true,
   "homepage": "http://dojotoolkit.org",
   "bugs": {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:
- [X] There is a related issue
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `engines` property to `package.json`.  This helps ensure the developers don't accidentally use versions of NodeJS (e.g. 4.X) that we no longer support.

Resolves #61
