### PR TITLE
Fix intern config package map

### DIFF
--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -50,10 +50,11 @@ export const loaders = {
 export const loaderOptions = {
 	// Packages that should be registered with the loader in each testing environment
 	packages: [
+		{ name: '@dojo', location: 'node_modules/@dojo' },
+		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
+		{ name: 'grunt-dojo2', location: 'node_modules/grunt-dojo2' },
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
-		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
-		{ name: '@dojo', location: 'node_modules/intern/node_modules/@dojo' }
 	]
 };
 


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The configuration has moved the custom Reporter to `grunt-dojo2` but the package map was not updated to allow the loader to resolve the path to the module.  In addition, the `@dojo` was pointed at a non existent path, therefore failing to resolve to the correct path for `@dojo` namespace packages.
