### PR TITLE
Adding check for parenthesis around arrow function parameters

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
 	"rules": {
 		"align": false,
+		"arrow-parens": true,
 		"ban": [],
 		"class-name": true,
 		"comment-format": [ true, "check-space" ],


### PR DESCRIPTION
**Type:** feature

**Description:**

After a recent comment on not having parenthesis around my single parameter arrow function, I thought maybe we could add this rule.

So instead of `someArray.map(a => a * 2)` you will need to use `someArray.map((a) => a * 2)`
