### PR TITLE
Adding coverage dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /typings
 .baseDir.ts
 .tscache
+coverage/
 coverage-unmapped.json
 coverage-final.json
 coverage-final.lcov


### PR DESCRIPTION
Adding intern 4 coverage directory to `.gitignore.