### PR TITLE
Add prettier and friends to package template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 **Description:**

--- a/README.md
+++ b/README.md
@@ -19,7 +19,17 @@ TODO: Add appropriate usage and instruction guidelines
 ## How do I contribute?
 
 We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "scripts": {
     "prepublish": "grunt peerDepInstall",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "devDependencies": {
@@ -32,7 +34,24 @@
     "@dojo/loader": "~0.1.1",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "husky": "0.14.3",
     "intern": "~4.1.0",
     "lint-staged": "6.0.0",
-    "tslint": "5.2.0",
+    "tslint": "5.8.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "@dojo/loader": "~0.1.1",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
     "husky": "0.14.3",
     "intern": "~4.1.0",
     "lint-staged": "6.0.0",
+    "tslint": "5.2.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"arrow-parens": true,
 		"ban": [],

--- a/tslint.json
+++ b/tslint.json
@@ -36,7 +36,6 @@
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
 		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
@@ -58,7 +57,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase to the package template.

Related to https://github.com/dojo/meta/issues/206